### PR TITLE
feat(tuner): Unify RTL naming conventions and add documentation

### DIFF
--- a/lib/verilog/tuner/README.md
+++ b/lib/verilog/tuner/README.md
@@ -1,0 +1,74 @@
+# Tuner RTL Naming and Coding Conventions
+
+This document outlines the naming and coding conventions for the SystemVerilog RTLs in the tuner subsystem. Adhering to these conventions is crucial for maintaining code quality, readability, and consistency.
+
+## 1. General Principles
+
+- **Clarity over Brevity**: Names should be descriptive and unambiguous.
+- **Consistency**: Apply the same conventions uniformly across all files.
+- **Use of `snake_case`**: All identifiers (signals, modules, files) use `snake_case` unless specified otherwise.
+
+## 2. File Naming
+
+- **Convention**: `project_subsystem_type.sv`
+- **Example**: `tuner_search_phy.sv`, `tuner_pwr_detect_if.sv`
+
+## 3. Module, Interface, and Package Naming
+
+- **Convention**: `lowercase_snake_case`
+- **Example**: `tuner_ctrl_arb_phy`, `tuner_pwr_detect_if`
+
+## 4. Port (Input/Output) Naming
+
+- **Convention**: Use prefixes for direction and domain: `[direction]_[domain]_[signal_name]`
+  - **Direction**: `i_` (input), `o_` (output).
+  - **Domain (optional)**: `_dig_` (digital), `_afe_` (analog front-end), `_cfg_` (configuration), `_mon_` (monitor).
+- **Example**: `i_dig_ring_pwr`, `o_dig_ring_tune`, `i_cfg_ring_tune_start`
+
+## 5. Internal Signal Naming
+
+- **Convention**: `lowercase_snake_case`.
+- **Prefix Standardization**:
+    - **Data Prefix**: Use a specific prefix for core data signals (e.g., `ring_tune` for the microring data value).
+    - **Action Prefix**: Use a shorter, more generic prefix for related control/handshake signals (e.g., `tune_` for `val`/`rdy`/`ack`).
+- **Example**: `state_next`, `tune_fire`, `ring_tune_commit`
+
+## 6. State Machine Enum Naming
+
+- **Convention**:
+  - **Enum Type**: `TypeName_e` (e.g., `tuner_phy_search_state_e`).
+  - **Enum Members**: `ALL_CAPS_SNAKE_CASE` (e.g., `SEARCH_IDLE`, `ARB_CTRL_TUNE`).
+
+## 7. Parameter Naming
+
+- **Convention**:
+  - **Module Parameters** (e.g., `parameter int WIDTH`): `ALL_CAPS_SNAKE_CASE`.
+  - **Local Parameters** (e.g., `localparam int SIZE`): `CamelCase`.
+- **Example**: `parameter int DAC_WIDTH`, `localparam int NumChannel`
+
+## 8. Interface Instance Naming
+
+- **Convention**: For an interface named `project_subsystem_if`, the instance should be `subsystem_if`.
+- **Example**: `tuner_pwr_detect_if` -> `pwr_detect_if`
+
+## 9. Signal Name Abbreviations
+
+To keep long names manageable without sacrificing clarity, use the following standard abbreviations:
+
+| Full Word   | Abbreviation |
+|-------------|--------------|
+| power       | pwr          |
+| control     | ctrl         |
+| value       | val          |
+| ready       | rdy          |
+| acknowledge | ack          |
+| window      | win          |
+| incremented | inc          |
+| decremented | dec          |
+| previous    | prev         |
+| number      | num          |
+| detected    | det          |
+| configuration| cfg         |
+| monitor     | mon          |
+| digital     | dig          |
+| analog FE   | afe          |

--- a/lib/verilog/tuner/tuner_ctrl_arb_if.sv
+++ b/lib/verilog/tuner/tuner_ctrl_arb_if.sv
@@ -8,7 +8,8 @@
 // Variable naming conventions:
 //    signals => snake_case
 //    Parameters (aliasing signal values) => SNAKE_CASE with all caps
-//    Parameters (not aliasing signal values) => CamelCase
+//    Module Parameters => ALL_CAPS_SNAKE_CASE
+//    Local Parameters => CamelCase
 //==============================================================================
 
 // verilog_format: off
@@ -36,9 +37,9 @@ interface tuner_ctrl_arb_if #(
   // Control -> Arbiter: Ring tuning value (to be sent to AFE)
   logic [DAC_WIDTH-1:0] ring_tune;
   // Controller
-  logic                 ring_tune_val    [NumChannel];
+  logic                 tune_val    [NumChannel];
   // Arbiter/AFE
-  logic                 ring_tune_rdy;
+  logic                 tune_rdy;
 
   // Arbiter -> Control: Committed ring tune and detected power
   logic [DAC_WIDTH-1:0] ring_tune_commit;
@@ -66,8 +67,8 @@ interface tuner_ctrl_arb_if #(
   // 1. Search takes priority over Lock
   // 2. If one claims ring_tune, it should also claim commit
 
-  function automatic logic get_ctrl_ring_tune_ch_ack(tuner_ctrl_ch_e ch);
-    return ring_tune_rdy && ring_tune_val[ch];
+  function automatic logic get_ctrl_tune_ch_ack(tuner_ctrl_ch_e ch);
+    return tune_rdy && tune_val[ch];
   endfunction
 
   function automatic logic get_ctrl_commit_ch_ack(tuner_ctrl_ch_e ch);
@@ -78,9 +79,9 @@ interface tuner_ctrl_arb_if #(
     logic search_tune_ack, search_commit_ack;
     logic lock_tune_ack, lock_commit_ack;
 
-    search_tune_ack = get_ctrl_ring_tune_ch_ack(CH_SEARCH);
+    search_tune_ack = get_ctrl_tune_ch_ack(CH_SEARCH);
     search_commit_ack = get_ctrl_commit_ch_ack(CH_SEARCH);
-    lock_tune_ack = get_ctrl_ring_tune_ch_ack(CH_LOCK);
+    lock_tune_ack = get_ctrl_tune_ch_ack(CH_LOCK);
     lock_commit_ack = get_ctrl_commit_ch_ack(CH_LOCK);
 
     if (search_tune_ack) return CH_SEARCH;
@@ -90,8 +91,8 @@ interface tuner_ctrl_arb_if #(
     else return CH_SEARCH;  // Default to search channel if no ack
   endfunction
 
-  function automatic logic get_ctrl_ring_tune_ack(tuner_ctrl_ch_e ch);
-    return get_ctrl_ring_tune_ch_ack(ch) && (select_channel() == ch);
+  function automatic logic get_ctrl_tune_ack(tuner_ctrl_ch_e ch);
+    return get_ctrl_tune_ch_ack(ch) && (select_channel() == ch);
   endfunction
 
   function automatic logic get_ctrl_commit_ack(tuner_ctrl_ch_e ch);
@@ -106,13 +107,13 @@ interface tuner_ctrl_arb_if #(
       output ctrl_active,
       output ctrl_refresh,
       output ring_tune,
-      output ring_tune_val,
-      input ring_tune_rdy,
+      output tune_val,
+      input tune_rdy,
       input ring_tune_commit,
       input pwr_commit,
       input commit_val,
       output commit_rdy,
-      import get_ctrl_ring_tune_ack,
+      import get_ctrl_tune_ack,
       import get_ctrl_commit_ack,
       import get_pwr_detect_active
   );
@@ -122,13 +123,13 @@ interface tuner_ctrl_arb_if #(
       input ctrl_active,
       input ctrl_refresh,
       input ring_tune,
-      input ring_tune_val,
-      output ring_tune_rdy,
+      input tune_val,
+      output tune_rdy,
       output ring_tune_commit,
       output pwr_commit,
       output commit_val,
       input commit_rdy,
-      import get_ctrl_ring_tune_ack,
+      import get_ctrl_tune_ack,
       import get_ctrl_commit_ack,
       import get_pwr_detect_active
   );

--- a/lib/verilog/tuner/tuner_lock_phy.sv
+++ b/lib/verilog/tuner/tuner_lock_phy.sv
@@ -6,7 +6,8 @@
 // Variable naming conventions:
 //    signals => snake_case
 //    Parameters (aliasing signal values) => SNAKE_CASE with all caps
-//    Parameters (not aliasing signal values) => CamelCase
+//    Module Parameters => ALL_CAPS_SNAKE_CASE
+//    Local Parameters => CamelCase
 //==============================================================================
 
 // verilog_format: off

--- a/lib/verilog/tuner/tuner_pwr_detect_if.sv
+++ b/lib/verilog/tuner/tuner_pwr_detect_if.sv
@@ -6,7 +6,8 @@
 // Variable naming conventions:
 //    signals => snake_case
 //    Parameters (aliasing signal values) => SNAKE_CASE with all caps
-//    Parameters (not aliasing signal values) => CamelCase
+//    Module Parameters => ALL_CAPS_SNAKE_CASE
+//    Local Parameters => CamelCase
 //==============================================================================
 
 

--- a/lib/verilog/tuner/tuner_pwr_detect_phy.sv
+++ b/lib/verilog/tuner/tuner_pwr_detect_phy.sv
@@ -7,7 +7,8 @@
 // Variable naming conventions:
 //    signals => snake_case
 //    Parameters (aliasing signal values) => SNAKE_CASE with all caps
-//    Parameters (not aliasing signal values) => CamelCase
+//    Module Parameters => ALL_CAPS_SNAKE_CASE
+//    Local Parameters => CamelCase
 //==============================================================================
 
 // verilog_format: off

--- a/lib/verilog/tuner/tuner_search_if.sv
+++ b/lib/verilog/tuner/tuner_search_if.sv
@@ -6,7 +6,8 @@
 // Variable naming conventions:
 //    signals => snake_case
 //    Parameters (aliasing signal values) => SNAKE_CASE with all caps
-//    Parameters (not aliasing signal values) => CamelCase
+//    Module Parameters => ALL_CAPS_SNAKE_CASE
+//    Local Parameters => CamelCase
 //==============================================================================
 
 


### PR DESCRIPTION
This commit standardizes the naming conventions across the tuner RTL codebase to improve readability, consistency, and maintainability.

Key changes include:
- Standardized interface instance names (e.g., `arb_if` -> `ctrl_arb_if`).
- Unified handshake signal names (e.g., `ring_tune_val` -> `tune_val`).
- Shortened long variable names with standard abbreviations (e.g., `pwr_detected_track_window` -> `pwr_det_track_win`).
- Corrected parameter naming convention documentation in all file headers.

A new `README.md` file has been added to the `verilog/tuner` directory to formally document the established conventions for future development.