### PR TITLE
Add multi-ring tuning logic

### DIFF
--- a/sim/tuner_search/dut.sv
+++ b/sim/tuner_search/dut.sv
@@ -210,7 +210,7 @@ module dut (
       .i_clk(i_clk),
       .i_rst(i_rst),
       .pwr_detect_if(pwr_detect_if),
-      .arb_if(ctrl_arb_if),
+      .ctrl_arb_if(ctrl_arb_if),
       .o_dig_afe_ring_tune(dac_tune),
       .i_afe_ring_tune_rdy(1'b1),
       .o_afe_ring_tune_val()

--- a/sim/tuner_search_row/CMakeLists.txt
+++ b/sim/tuner_search_row/CMakeLists.txt
@@ -1,0 +1,27 @@
+get_filename_component(TB_NAME "${CMAKE_CURRENT_SOURCE_DIR}" NAME)
+
+set(VERI_SRC "${VERILOG_SIM_DIR}/${TB_NAME}/dut.sv")
+set(SIM_SOURCES "${VERILOG_SIM_DIR}/${TB_NAME}/tb.cpp")
+add_verilog_library_sources(VERI_SRC PHOTONICS TUNER CIRCUITS)
+
+# set(VERI_ARGS "-sv")
+
+message(STATUS "${TB_NAME} sources: ${VERI_SRC}")
+
+# Add testbench using helper
+add_verilated_testbench(
+  "${TB_NAME}"
+  dut
+  "${CMAKE_CURRENT_SOURCE_DIR}/tb.cpp"
+  SOURCES
+  ${VERI_SRC}
+  VERILATOR_ARGS
+  ${VERI_ARGS}
+  INCLUDE_DIRS
+  "${CPP_LIB_DIR}"
+  EXTRA_SRC
+  ${SIM_SOURCES}
+  ADD_WAVE_TARGET
+  CSV
+  PREFIX
+  Vsim)

--- a/sim/tuner_search_row/dut.sv
+++ b/sim/tuner_search_row/dut.sv
@@ -1,0 +1,266 @@
+//==============================================================================
+// Author: Sunjin Choi
+// Description: 
+// Signals:
+// Note: 
+// Variable naming conventions:
+//    signals => snake_case
+//    Parameters (aliasing signal values) => SNAKE_CASE with all caps
+//    Parameters (not aliasing signal values) => CamelCase
+//==============================================================================
+
+// verilog_format: off
+`timescale 1ns/1ps
+`default_nettype none
+// verilog_format: on
+
+`define DAC_WIDTH 8
+`define ADC_WIDTH 8
+`define NUM_TARGET 4
+`define NUM_WAVES 2
+`define NUM_CHANNEL 2
+
+import wdm_pkg::*;
+import tuner_phy_pkg::*;
+
+module dut (
+    input var logic i_clk,
+    input var logic i_rst,
+
+    // input signals
+    input var real i_pwr,
+    input var real i_wvl_ls  [  `NUM_WAVES],
+    input var real i_wvl_ring[`NUM_CHANNEL],
+
+    // output signals
+    output real o_pwr_thru,
+    output real o_pwr_drop[`NUM_CHANNEL],
+
+    /*input var logic [`DAC_WIDTH-1:0] i_dac_tune,*/
+    output logic [`ADC_WIDTH-1:0] o_adc_thru,
+    output logic [`ADC_WIDTH-1:0] o_adc_drop[`NUM_CHANNEL],
+    output logic [`DAC_WIDTH-1:0] o_dac_tune[`NUM_CHANNEL],
+
+    output logic o_dig_pwr_drop_detect_val[`NUM_CHANNEL],
+    output logic [`ADC_WIDTH-1:0] o_dig_pwr_drop_detected[`NUM_CHANNEL],
+
+    input logic i_dig_search_trig_val[`NUM_CHANNEL],
+    input logic i_dig_search_peaks_rdy[`NUM_CHANNEL],
+    output logic o_dig_search_peaks_val[`NUM_CHANNEL],
+    input logic [`DAC_WIDTH-1:0] i_dig_ring_tune_start[`NUM_CHANNEL],
+    input logic [`DAC_WIDTH-1:0] i_dig_ring_tune_end[`NUM_CHANNEL],
+    input logic [`DAC_WIDTH-1:0] i_dig_ring_tune_stride[`NUM_CHANNEL],
+
+    // peak detect signal and collected tuner codes for codes
+    output logic [`DAC_WIDTH-1:0] o_dig_ring_tune_peaks[`NUM_CHANNEL][`NUM_TARGET],
+    output logic [`ADC_WIDTH-1:0] o_dig_pwr_detected_peaks[`NUM_CHANNEL][`NUM_TARGET],
+    output logic [$clog2(`NUM_TARGET)-1:0] o_dig_ring_tune_peaks_cnt[`NUM_CHANNEL],
+
+    output logic o_mon_peak_commit[`NUM_CHANNEL],
+    output logic o_mon_search_active_update[`NUM_CHANNEL],
+    output logic [`ADC_WIDTH-1:0] o_mon_ring_pwr[`NUM_CHANNEL],
+    output logic [`DAC_WIDTH-1:0] o_mon_ring_tune[`NUM_CHANNEL],
+    output tuner_phy_search_state_e o_mon_state[`NUM_CHANNEL]
+
+);
+
+  `DECLARE_WAVES_TYPE(2);
+
+  // ----------------------------------------------------------------------
+  // Assigns
+  // ----------------------------------------------------------------------
+  WAVES_TYPE waves_in;
+  WAVES_TYPE waves_thru;
+  WAVES_TYPE waves_drop[`NUM_CHANNEL];
+  real wvls[WAVES_WIDTH];
+  real pwrs[WAVES_WIDTH];
+
+  real ana_tune[`NUM_CHANNEL];
+  real real_tuning_dist[`NUM_CHANNEL];
+  logic [`DAC_WIDTH-1:0] dac_tune[`NUM_CHANNEL];
+  /*logic [`ADC_WIDTH-1:0] pwr_drop_detected;*/
+
+  /*logic pwr_read_rdy;
+   *logic pwr_read_val;
+   *logic pwr_detect_val;
+   *logic pwr_detect_rdy;*/
+
+  always_comb begin
+    for (int i = 0; i < WAVES_WIDTH; i++) begin
+      wvls[i] = i_wvl_ls[i];
+      pwrs[i] = i_pwr;
+    end
+    for (int j = 0; j < `NUM_CHANNEL; j++) begin
+      real_tuning_dist[j] = ana_tune[j];
+    end
+  end
+
+  assign o_dac_tune = dac_tune;
+  /*assign o_dig_pwr_drop_detected = pwr_drop_detected;*/
+  /*assign o_dig_pwr_drop_detect_val = pwr_detect_val;*/
+
+  tuner_pwr_detect_if #(
+      .ADC_WIDTH(`ADC_WIDTH)
+  ) pwr_detect_if[`NUM_CHANNEL] (
+      .i_clk(i_clk),
+      .i_rst(i_rst)
+  );
+  /*assign pwr_detect_if.read_val = 1'b1;
+   *assign pwr_detect_if.detect_rdy = 1'b1;
+   *assign o_dig_pwr_drop_detected = pwr_detect_if.detect_val;
+   *assign o_dig_pwr_thru_detect = pwr_detect_if.detect_data;*/
+  // assignments for each channel are handled in the generate block
+
+  tuner_search_if #(
+      .ADC_WIDTH (`ADC_WIDTH),
+      .DAC_WIDTH (`DAC_WIDTH),
+      .NUM_TARGET(`NUM_TARGET)
+  ) search_if[`NUM_CHANNEL] (
+      .i_clk(i_clk),
+      .i_rst(i_rst)
+  );
+
+  tuner_ctrl_arb_if #(
+      .ADC_WIDTH(`ADC_WIDTH),
+      .DAC_WIDTH(`DAC_WIDTH)
+  ) ctrl_arb_if[`NUM_CHANNEL] ();
+  // ----------------------------------------------------------------------
+
+  // ----------------------------------------------------------------------
+  // Instances
+  // ----------------------------------------------------------------------
+  laser #(
+      .waves_t  (WAVES_TYPE),
+      .NUM_WAVES(WAVES_WIDTH)
+  ) laser (
+      .i_real_pwr  (pwrs),
+      .i_real_wvl  (wvls),
+      .o_phot_waves(waves_in)
+  );
+
+  /*microring #(
+   *    .waves_t(WAVES_TYPE),
+   *    [>.ResonanceWavelength(i_wvl_ring),<]
+   *    .FWHM(0.2),
+   *    .TuningFullScale(10.0)
+   *) microring (
+   *    .i_phot_waves(waves_in),
+   *    .i_real_wvl_ring(i_wvl_ring),
+   *    .i_real_tuning_dist(ana_tune),  // No tuning for now
+   *    .i_real_temperature(0.0),  // No temperature sensitivity for now
+   *    .o_phot_waves_drop(waves_drop),
+   *    .o_phot_waves_thru(waves_thru)
+   *);*/
+
+  microringrow #(
+      .waves_t      (WAVES_TYPE),
+      .NUM_CHANNEL  (`NUM_CHANNEL),
+      .FWHM         (0.25),
+      .TuningFullScale(10.0)
+  ) microringrow (
+      .i_phot_waves     (waves_in),
+      .i_real_wvl_ring  (i_wvl_ring),
+      .i_real_tuning_dist(real_tuning_dist),
+      .i_real_temperature('{default: 0.0}),  // No temperature sensitivity for now
+      .o_phot_waves_drop(waves_drop),
+      .o_phot_waves_thru(waves_thru)
+  );
+
+  // Per-channel tuning and detection hardware
+  generate
+    for (genvar ch = 0; ch < `NUM_CHANNEL; ch++) begin : g_ring_hw
+      dac #(
+          .DAC_WIDTH(`DAC_WIDTH),
+          .FullScaleRange(1.0)
+      ) dac_tune_afe (
+          .i_dig(dac_tune[ch]),
+          .o_ana(ana_tune[ch])
+      );
+
+      photodetector #(
+          .waves_t(WAVES_TYPE)
+      ) pd_drop (
+          .i_phot_waves  (waves_drop[ch]),
+          .o_real_current(o_pwr_drop[ch])
+      );
+
+      adc #(
+          .ADC_WIDTH(`ADC_WIDTH),
+          .FullScaleRange(1.0)
+      ) adc_drop (
+          .i_ana(o_pwr_drop[ch]),
+          .o_dig(o_adc_drop[ch])
+      );
+
+      tuner_pwr_detect_phy pwr_drop_detect (
+          .i_clk(i_clk),
+          .i_rst(i_rst),
+          .i_dig_ring_pwr(o_adc_drop[ch]),
+          .pwr_detect_if(pwr_detect_if[ch])
+      );
+
+      tuner_ctrl_arb_phy ctrl_arb (
+          .i_clk(i_clk),
+          .i_rst(i_rst),
+          .pwr_detect_if(pwr_detect_if[ch]),
+          .ctrl_arb_if(ctrl_arb_if[ch]),
+          .o_dig_afe_ring_tune(dac_tune[ch]),
+          .i_afe_ring_tune_rdy(1'b1),
+          .o_afe_ring_tune_val()
+      );
+
+      tuner_search_phy #(
+          .DAC_WIDTH (`DAC_WIDTH),
+          .ADC_WIDTH (`ADC_WIDTH),
+          .NUM_TARGET(`NUM_TARGET)
+      ) drop_search (
+          .i_clk(i_clk),
+          .i_rst(i_rst),
+
+          .i_dig_ring_tune_start(i_dig_ring_tune_start[ch]),
+          .i_dig_ring_tune_end(i_dig_ring_tune_end[ch]),
+          .i_dig_ring_tune_stride(i_dig_ring_tune_stride[ch]),
+
+          .ctrl_arb_if(ctrl_arb_if[ch]),
+          .search_if(search_if[ch])
+      );
+
+      assign search_if[ch].trig_val  = i_dig_search_trig_val[ch];
+      assign search_if[ch].peaks_rdy = i_dig_search_peaks_rdy[ch];
+      assign o_dig_search_peaks_val[ch] = search_if[ch].peaks_val;
+      assign o_dig_ring_tune_peaks[ch] = search_if[ch].ring_tune_peaks;
+      assign o_dig_pwr_detected_peaks[ch] = search_if[ch].pwr_peaks;
+      assign o_dig_ring_tune_peaks_cnt[ch] = search_if[ch].peaks_cnt;
+
+      assign o_mon_peak_commit[ch]          = search_if[ch].mon_peak_commit;
+      assign o_mon_search_active_update[ch] = search_if[ch].mon_search_active_update;
+      assign o_mon_ring_pwr[ch]             = search_if[ch].mon_ring_pwr;
+      assign o_mon_ring_tune[ch]            = search_if[ch].mon_ring_tune;
+      assign o_mon_state[ch]                = search_if[ch].mon_state;
+
+      assign o_dig_pwr_drop_detected[ch]   = pwr_detect_if[ch].detect_data;
+      assign o_dig_pwr_drop_detect_val[ch] = pwr_detect_if[ch].detect_val;
+    end
+  endgenerate
+
+  photodetector #(
+      .waves_t(WAVES_TYPE)
+  ) pd_thru (
+      .i_phot_waves  (waves_thru),
+      .o_real_current(o_pwr_thru)
+  );
+
+  adc #(
+      .ADC_WIDTH(`ADC_WIDTH),
+      .FullScaleRange(1.0)
+  ) adc_thru (
+      .i_ana(o_pwr_thru),
+      .o_dig(o_adc_thru)
+  );
+
+  // ----------------------------------------------------------------------
+
+endmodule
+
+`default_nettype wire
+

--- a/sim/tuner_search_row/tb.cpp
+++ b/sim/tuner_search_row/tb.cpp
@@ -1,0 +1,232 @@
+#include "Vsim.h"
+#include "utils/sweep.hpp"
+#include "verilated.h"
+#include "verilated_vcd_c.h"
+#include <csv2/writer.hpp>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <array>
+
+class SearchPhyMonitor {
+public:
+  typedef struct {
+    double time;
+    int tune_code;
+    double i_pwr;
+    double o_pwr;
+    int state_enum;
+  } search_record_t;
+
+  SearchPhyMonitor(Vsim *dut, int ring, int interval = 1)
+      : dut_(dut), ring_(ring), sample_interval_(interval) {}
+
+  void sample(vluint64_t time, bool force, bool print) {
+    bool do_sample = force || ((interval_count_ & sample_interval_) == 0);
+
+    if (do_sample) {
+      search_record_t r;
+      r.time = static_cast<double>(time);
+      r.tune_code = dut_->o_mon_ring_tune[ring_];
+      r.i_pwr = dut_->i_pwr;
+      r.o_pwr = static_cast<double>(dut_->o_mon_ring_pwr[ring_]) / 256.0;
+      /*r.o_pwr = dut_->o_pwr_drop;*/
+      r.state_enum = dut_->o_mon_state[ring_];
+      records_.push_back(r);
+
+      if (print) {
+        std::cout << "[" << r.time << " ps] "
+                  << "State=" << state_string(r.state_enum)
+                  << " tune=" << r.tune_code << " i_pwr=" << r.i_pwr
+                  << " o_pwr=" << r.o_pwr << "\n";
+      }
+
+      if (force) {
+        interval_count_ = 0;
+      }
+    }
+    interval_count_++;
+  }
+
+  void write_csv(const std::string &filename) const {
+    std::ofstream ofs(filename);
+    csv2::Writer<csv2::delimiter<','>> writer(ofs);
+
+    // Write header
+    writer.write_row(csv_row_t{"time", "tune_code", "i_pwr", "o_pwr", "state"});
+    for (auto &r : records_) {
+      writer.write_row(
+          csv_row_t{std::to_string(r.time), std::to_string(r.tune_code),
+                    std::to_string(r.i_pwr), std::to_string(r.o_pwr),
+                    state_string(r.state_enum)});
+    }
+    ofs.close();
+  }
+
+  void change_sample_interval(int new_interval) {
+    if (new_interval > 0) {
+      sample_interval_ = new_interval;
+      interval_count_ = 0; // Reset the interval count
+    } else {
+      std::cerr << "Invalid sample interval: " << new_interval
+                << ". Must be greater than 0." << std::endl;
+    }
+  }
+
+private:
+  Vsim *dut_;
+  int ring_;
+  int sample_interval_;
+  std::vector<search_record_t> records_;
+  int state_prev_ = -1;
+  int interval_count_ = 0;
+
+  static std::string state_string(int state_enum) {
+    switch (state_enum) {
+    case 0:
+      return "IDLE";
+    case 1:
+      return "INIT";
+    case 2:
+      return "ACTIVE";
+    case 3:
+      return "DONE";
+    case 4:
+      return "ERROR";
+    case 5:
+      return "INTR";
+    default:
+      return "UNKNOWN";
+    }
+  }
+};
+
+int main(int argc, char **argv) {
+
+  // Construct a VerilatedContext to hold simulation time, etc
+  /*VerilatedContext *const contextp = new VerilatedContext;*/
+  auto contextp = std::make_unique<VerilatedContext>();
+
+  Verilated::traceEverOn(true);
+
+  // Pass arguments so Verilated code can see them, e.g. $value$plusargs
+  // This needs to be called before you create any model
+  contextp->commandArgs(argc, argv);
+
+  /*VerilatedVcdC *tfp = new VerilatedVcdC;*/
+  auto tfp = std::make_unique<VerilatedVcdC>();
+  // Default does not work out -- manually set time unit and resolution
+  tfp->set_time_unit("ps");
+  tfp->set_time_resolution("ps");
+
+  // Construct the Verilated model, from Vsim.h generated from Verilating
+  /*Vsim *const dut = new Vsim{contextp};*/
+  const auto dut = std::make_unique<Vsim>(contextp.get());
+
+  dut->trace(tfp.get(), 99);
+  tfp->open("waveform.vcd");
+
+  // Time variable
+  vluint64_t main_time = 0;
+  const vluint64_t clk_period = 10;
+
+  constexpr size_t kNumRings = 2;
+  std::array<SearchPhyMonitor, kNumRings> search_monitor{
+      SearchPhyMonitor(dut.get(), 0, 8), SearchPhyMonitor(dut.get(), 1, 8)};
+
+  auto advance_half_clk = [&]() {
+    main_time += clk_period / 2;
+    dut->i_clk = !dut->i_clk;
+    dut->eval();
+    /*tfp->dump(main_time);*/
+  };
+
+  auto advance_clk = [&](size_t ring) {
+    auto search_phy_state_prev = dut->o_mon_state[ring];
+
+    advance_half_clk();
+    advance_half_clk();
+    tfp->dump(main_time);
+
+    auto search_phy_state = dut->o_mon_state[ring];
+    bool force_sample = (dut->o_mon_search_active_update[ring] ||
+                         (search_phy_state != search_phy_state_prev));
+    search_monitor[ring].sample(main_time, force_sample, true);
+  };
+
+  auto search_range_string = [&](size_t ring) {
+    return "Search Range: " + std::to_string(dut->i_dig_ring_tune_start[ring]) +
+           " to " + std::to_string(dut->i_dig_ring_tune_end[ring]);
+  };
+
+  auto search_routine = [&](size_t ring, int start, int end, int stride = 1,
+                            bool print = true) {
+    dut->i_dig_ring_tune_start[ring] = start;
+    dut->i_dig_ring_tune_end[ring] = end;
+    dut->i_dig_ring_tune_stride[ring] = stride;
+
+    search_monitor[ring].change_sample_interval(8);
+    dut->i_dig_search_trig_val[ring] = 1;
+    advance_clk(ring);
+    dut->i_dig_search_trig_val[ring] = 0;
+
+    while (!dut->o_dig_search_peaks_val[ring]) {
+      advance_clk(ring);
+    }
+
+    search_monitor[ring].change_sample_interval(2);
+    advance_clk(ring);
+    dut->i_dig_search_peaks_rdy[ring] = 1;
+    advance_clk(ring);
+
+    if (print) {
+      std::cout << "Search complete, number of peaks found: "
+                << (int)dut->o_dig_ring_tune_peaks_cnt[ring] << " ("
+                << search_range_string(ring) << ")" << std::endl;
+
+      for (int i = 0; i < (int)dut->o_dig_ring_tune_peaks_cnt[ring]; i++) {
+        std::cout << "Peak [" << i
+                  << "]: Code: " << (int)dut->o_dig_ring_tune_peaks[ring][i]
+                  << " Pwr: " << (int)dut->o_dig_pwr_detected_peaks[ring][i]
+                  << std::endl;
+      }
+    }
+  };
+
+  // DUT initialization
+  dut->i_pwr = 1.0;
+  dut->i_wvl_ls[0] = 1300.0;
+  dut->i_wvl_ls[1] = 1302.0;
+
+  const std::array<double, 2> wvl_ring = {1295.0, 1298.0};
+  for (size_t i = 0; i < wvl_ring.size(); ++i) {
+    dut->i_wvl_ring[i] = wvl_ring[i];
+  }
+  for (size_t r = 0; r < kNumRings; ++r) {
+    dut->i_dig_search_trig_val[r] = 0;
+    dut->i_dig_search_peaks_rdy[r] = 0;
+  }
+
+  dut->i_clk = 0; // Clock starts low
+
+  for (size_t ring = 0; ring < wvl_ring.size(); ++ring) {
+    dut->i_rst = 1;
+    advance_clk(ring);
+    advance_clk(ring);
+    dut->i_rst = 0;
+    advance_clk(ring);
+
+    std::cout << "--- Running search on ring " << ring << " ---" << std::endl;
+    search_routine(ring, 0, 255, 2, true);
+    search_routine(ring, 140, 255, 0, true);
+  }
+
+  for (size_t r = 0; r < kNumRings; ++r) {
+    search_monitor[r].write_csv("search_waveform_ring" + std::to_string(r) + ".csv");
+  }
+
+  // Clean up
+  tfp->close();
+
+  return 0;
+}


### PR DESCRIPTION
## Summary
- support per-ring tuner instances in `tuner_search_row` DUT
- update testbench to drive each ring separately

## Testing
- `cmake .. -DVERILOG_SRC_DIR=$VERILOG_SRC_DIR -DVERILOG_LIB_DIR=$VERILOG_LIB_DIR -DVERILOG_SIM_DIR=$VERILOG_SIM_DIR -DCPP_LIB_DIR=$CPP_LIB_DIR`
- `make run-tuner_search_row`


------
https://chatgpt.com/codex/tasks/task_e_68697663cfb0832dab25f3c36136d3e6